### PR TITLE
`enableSwitchAnimation` and `switchAnimationConfig` for slivers

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -145,12 +145,20 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
+  sliver_tools:
+    dependency: transitive
+    description:
+      name: sliver_tools
+      sha256: eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.12"
   source_span:
     dependency: transitive
     description:

--- a/lib/src/skeletonizer_config.dart
+++ b/lib/src/skeletonizer_config.dart
@@ -268,18 +268,18 @@ class SwitchAnimationConfig {
   final Duration? reverseDuration;
 
   /// The transition builder
-  final AnimatedSwitcherTransitionBuilder transitionBuilder;
+  final AnimatedSwitcherTransitionBuilder? transitionBuilder;
 
   /// The layout builder
-  final AnimatedSwitcherLayoutBuilder layoutBuilder;
+  final AnimatedSwitcherLayoutBuilder? layoutBuilder;
 
   /// Default constructor
   const SwitchAnimationConfig({
     this.duration = const Duration(milliseconds: 300),
     this.switchInCurve = Curves.linear,
     this.switchOutCurve = Curves.linear,
-    this.transitionBuilder = AnimatedSwitcher.defaultTransitionBuilder,
-    this.layoutBuilder = AnimatedSwitcher.defaultLayoutBuilder,
+    this.transitionBuilder,
+    this.layoutBuilder,
     this.reverseDuration,
   });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  sliver_tools: ^0.2.12
 
 
 dev_dependencies:


### PR DESCRIPTION
This pr adds support for `enableSwitchAnimation` and `switchAnimationConfig` for slivers. Uses [sliver_tools](https://pub.dev/packages/sliver_tools) package to provide necessary `layoutBuilder` and `transitionBuilder`.