### PR TITLE
fix: Remove unnecessary `uses-material-design: true` from pubspec.yaml (#31)

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -111,18 +111,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -145,7 +145,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.2"
+    version: "2.1.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -216,5 +216,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,5 +29,5 @@ dev_dependencies:
 
 
 flutter:
-  uses-material-design: true
+  uses-material-design: false
 


### PR DESCRIPTION
Hi @Milad-Akarie, thanks for the great package! This PR addresses the issue reported in #31.

Closes #31

## Problem

When `skeletonizer` is used in a Flutter project that has `uses-material-design: false`, Flutter emits the following warning:

```
package:skeletonizer has `uses-material-design: true` set but the primary pubspec
contains `uses-material-design: false`. If the application needs material icons,
then `uses-material-design` must be set to true.
```

This warning is confusing and misleading for users whose apps intentionally opt out of Material icons.

## Root Cause

`pubspec.yaml` had `uses-material-design: true` set in the `flutter:` section, but the library's production code (`lib/`) does not use `Icons.*` anywhere. The flag was never needed.

`Icons.*` appears only in test files (`test/`), which are not included when the package is consumed by a user's app.

## Change

Set `uses-material-design: false` in `pubspec.yaml`.

```yaml
# before
flutter:
  uses-material-design: true

# after
flutter:
  uses-material-design: false
```

## Verification

All 277 non-golden tests pass with this change:

```
flutter test --exclude-tags=golden
...
00:02 +277: All tests passed!
```
